### PR TITLE
feat(player): add dynamic cast button and conditional control visibility

### DIFF
--- a/bunny-stream-api/src/main/java/net/bunnystream/api/settings/domain/model/PlayerSettings.kt
+++ b/bunny-stream-api/src/main/java/net/bunnystream/api/settings/domain/model/PlayerSettings.kt
@@ -28,4 +28,5 @@ data class PlayerSettings(
     val progressEnabled = controls.contains("progress")
     val durationEnabled = controls.contains("duration")
     val playButtonEnabled = controls.contains("play-large") || controls.contains("play")
+    val castButtonEnabled = controls.contains("chromecast")
 }

--- a/bunny-stream-player/src/main/java/net/bunnystream/bunnystreamplayer/ui/widget/BunnyPlayerView.kt
+++ b/bunny-stream-player/src/main/java/net/bunnystream/bunnystreamplayer/ui/widget/BunnyPlayerView.kt
@@ -576,9 +576,13 @@ class BunnyPlayerView @JvmOverloads constructor(
         })
 
         setControllerVisibilityListener(ControllerVisibilityListener {
+            if(playerSettings?.rewindEnabled == true) {
+                replyButton.visibility = it
+            }
+            if(playerSettings?.fastForwardEnabled == true){
+                forwardButton.visibility = it
+            }
             bottomBar.visibility = it
-            replyButton.visibility = it
-            forwardButton.visibility = it
             if (it == View.VISIBLE) {
                 timeBar.showScrubber()
             } else {
@@ -648,6 +652,7 @@ class BunnyPlayerView @JvmOverloads constructor(
         subtitle.isVisible = playerSettings?.subtitlesEnabled == true
         timeBar.isVisible = playerSettings?.progressEnabled == true
         playPauseButton.isVisible = playerSettings?.playButtonEnabled == true
+        castButton.isVisible = playerSettings?.castButtonEnabled == true
 
         progressDurationDivider.isVisible = progressTextView.isVisible && durationTextView.isVisible
     }


### PR DESCRIPTION
- Introduce `castButtonEnabled` flag in `PlayerSettings` to toggle Chromecast control
- Update `BunnyPlayerView`’s `setControllerVisibilityListener` to only show rewind and fast-forward buttons when enabled in settings
- Respect `castButtonEnabled` in `updateControlsVisibility` to dynamically hide or show the cast button