### PR TITLE
Setup publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,113 +3,78 @@ name: Deploy App
 on:
   pull_request:
     branches: [ develop ]
-
   workflow_dispatch:
 
 jobs:
-  lint_check:
-    name: Lint check
-    runs-on: ubuntu-latest 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Lint check
-        run: ./gradlew .detekt
-        
   unit_tests:
     name: Run unit tests
-    runs-on: ubuntu-latest 
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Unit tests
-        run: ./gradlew testDebugUnitTest
-
-  instrumentation_tests:
-    name: Instrumentation tests
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        api-level: [29]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
-
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
-        
-
-      - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew connectedCheck
-        
-  build:
-    name: Build app
-    needs: [ lint_check, unit_tests, instrumentation_tests ]
     runs-on: ubuntu-latest
-
+    if: ${{ false }}       # TMP disable job for testing
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: 17
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --no-daemon --stacktrace
+
+  publish:
+    name: Publish to Maven Central
+    #needs: unit_tests
+    runs-on: ubuntu-latest
+    env:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      MAVEN_KEY:        ${{ secrets.MAVEN_KEY }}           # ASCII-armored secret key
+      MAVEN_KEY_PASSWORD: ${{ secrets.MAVEN_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java, OSSRH creds & import GPG key
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          server-id: ossrh                                # matches your nexusPublishing repo id
+          server-username: ${{ secrets.OSSRH_USERNAME }}
+          server-password: ${{ secrets.OSSRH_PASSWORD }}
+          gpg-private-key: ${{ secrets.MAVEN_KEY }}       # your exported --armor key
+          gpg-passphrase: ${{ secrets.MAVEN_KEY_PASSWORD }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Build Release APK
-        run: ./gradlew :app:assembleDebug
+      - name: Publish artifacts
+        run: ./gradlew publishToMavenCentral --no-daemon --stacktrace
 
   distribute:
-    name: Distribute
-    needs: [ build ]
-    runs-on: ubuntu-latest 
-
+    name: Distribute APK
+    needs: unit_tests
+    runs-on: ubuntu-latest
+    if: ${{ false }}       # TMP disable job for testing
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: 17
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v3.2.0
 
       - name: Build Debug APK
-        run: ./gradlew :app:assembleDebug
+        run: ./gradlew :app:assembleDebug --no-daemon
 
-      - name: Upload artifact to Firebase App Distribution
+      - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
-          appId: ${{secrets.FIREBASE_APP_ID}}
+          appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: Testers
           file: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,6 @@ jobs:
     name: Publish to Maven Central
     #needs: unit_tests
     runs-on: ubuntu-latest
-    env:
-      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      MAVEN_KEY:        ${{ secrets.MAVEN_KEY }}           # ASCII-armored secret key
-      MAVEN_KEY_PASSWORD: ${{ secrets.MAVEN_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -40,17 +35,17 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          server-id: ossrh                                # matches your nexusPublishing repo id
-          server-username: ${{ secrets.OSSRH_USERNAME }}
-          server-password: ${{ secrets.OSSRH_PASSWORD }}
-          gpg-private-key: ${{ secrets.MAVEN_KEY }}       # your exported --armor key
-          gpg-passphrase: ${{ secrets.MAVEN_KEY_PASSWORD }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
       - name: Publish artifacts
-        run: ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace
+        run: |
+          ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace \
+            -PossrhUsername="${{ secrets.OSSRH_USERNAME }}" \
+            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}" \
+            -Dsigning.key="${{ secrets.MAVEN_KEY }}" \
+            -Dsigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
 
   distribute:
     name: Distribute APK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Deploy App
 
 on:
-  pull_request:
-    branches: [ develop ]
+  push:
+    branches:
+      - setup-publishing
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,77 +1,64 @@
-name: Deploy App
+# Workflow name shown in GitHub Actions UI
+name: Test and Upload Artifact App
 
+# When to run this workflow:
 on:
+  # Trigger on any push to 'main'
   push:
     branches:
-      - setup-publishing
+      - main
+  # Allow manual triggering from the Actions tab
   workflow_dispatch:
 
 jobs:
+  # First job: run your unit tests
   unit_tests:
     name: Run unit tests
     runs-on: ubuntu-latest
-    if: ${{ false }}       # TMP disable job for testing
     steps:
+      # Check out the repository code
       - uses: actions/checkout@v4
 
+      # Set up JDK 17 (Temurin distribution)
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
+      # Execute your Android unit tests
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --no-daemon --stacktrace
 
-  publish:
-    name: Publish to GitHub Packages
-    #needs: unit_tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Java, OSSRH creds & import GPG key
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
-      - name: Publish artifacts
-        run: |
-          ./gradlew publishReleasePublicationToGitHubPackagesRepository --no-daemon --stacktrace \
-            -Psigning.key="${{ secrets.MAVEN_KEY }}" \
-            -Psigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  # Second job: build the APK and upload it
   distribute:
-    name: Distribute APK
+    name: Upload APK as Artifact
     needs: unit_tests
     runs-on: ubuntu-latest
-    if: ${{ false }}       # TMP disable job for testing
     steps:
+      # Re-checkout code at the start of this job
       - uses: actions/checkout@v4
 
+      # Set up JDK again for Gradle
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
+      # Install the Android SDK to build the app
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.0
 
+      # Build the Debug APK with Gradle
       - name: Build Debug APK
         run: ./gradlew :app:assembleDebug --no-daemon
 
-      - name: Upload to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
+      # Upload the generated Debug APK as a GitHub Actions artifact
+      - name: Upload Debug APK
+        uses: actions/upload-artifact@v3
         with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
-          groups: Testers
-          file: app/build/outputs/apk/debug/app-debug.apk
+          # The name shown in the Actions UI for this artifact
+          name: app-debug-apk
+          # Path to the APK file produced by the build
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,44 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Debug GPG key presence & format
+        shell: bash
+        env:
+          GPG_KEY: ${{ secrets.MAVEN_KEY }}
+        run: |
+          set -x  # show each command
+          
+          # 1) Check that the env var is non-empty and measure its length
+          if [[ -z "$GPG_KEY" ]]; then
+            echo "❌ GPG_KEY is empty!" >&2
+            exit 1
+          fi
+          echo "✅ GPG_KEY length: ${#GPG_KEY}"   #  [oai_citation:0‡stackoverflow.com](https://stackoverflow.com/questions/17368067/length-of-string-in-bash?utm_source=chatgpt.com)
+          
+          # 2) Preview header and footer to confirm proper armor
+          echo "----header----"
+          echo "$GPG_KEY" | head -n1
+          echo "----footer----"
+          echo "$GPG_KEY" | tail -n1
+          
+          # 3) Verify BEGIN/END markers
+          if echo "$GPG_KEY" | grep -q "BEGIN PGP PRIVATE KEY BLOCK"; then
+            echo "✅ Header OK"
+          else
+            echo "❌ Missing BEGIN marker" >&2
+          fi
+          if echo "$GPG_KEY" | grep -q "END PGP PRIVATE KEY BLOCK"; then
+            echo "✅ Footer OK"
+          else
+            echo "❌ Missing END marker" >&2
+          fi
+          
+          # 4) Try importing and list what you have
+          echo "----importing----"
+          echo "$GPG_KEY" | gpg --batch --import   #  [oai_citation:1‡unix.stackexchange.com](https://unix.stackexchange.com/questions/184947/how-to-import-secret-gpg-key-copied-from-one-machine-to-another?utm_source=chatgpt.com)
+          echo "----secret keys in keyring----"
+          gpg --list-secret-keys --keyid-format LONG  
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Publish artifacts
-        run: ./gradlew publishToMavenCentral --no-daemon --stacktrace
+        run: ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace
 
   distribute:
     name: Distribute APK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew testDebugUnitTest --no-daemon --stacktrace
 
   publish:
-    name: Publish to Maven Central
+    name: Publish to GitHub Packages
     #needs: unit_tests
     runs-on: ubuntu-latest
     steps:
@@ -39,18 +39,14 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Debug
-        run: |
-          echo "${{ secrets.OSSRH_USERNAME }}" | base64
-          echo "${{ secrets.OSSRH_PASSWORD }}" | base64
-
       - name: Publish artifacts
         run: |
-          ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace \
-            -PossrhUsername="${{ secrets.OSSRH_USERNAME }}" \
-            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}" \
+          ./gradlew publishReleasePublicationToGitHubPackagesRepository --no-daemon --stacktrace \
             -Psigning.key="${{ secrets.MAVEN_KEY }}" \
             -Psigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   distribute:
     name: Distribute APK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,44 +36,6 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Debug GPG key presence & format
-        shell: bash
-        env:
-          GPG_KEY: ${{ secrets.MAVEN_KEY }}
-        run: |
-          set -x  # show each command
-          
-          # 1) Check that the env var is non-empty and measure its length
-          if [[ -z "$GPG_KEY" ]]; then
-            echo "❌ GPG_KEY is empty!" >&2
-            exit 1
-          fi
-          echo "✅ GPG_KEY length: ${#GPG_KEY}"   #  [oai_citation:0‡stackoverflow.com](https://stackoverflow.com/questions/17368067/length-of-string-in-bash?utm_source=chatgpt.com)
-          
-          # 2) Preview header and footer to confirm proper armor
-          echo "----header----"
-          echo "$GPG_KEY" | head -n1
-          echo "----footer----"
-          echo "$GPG_KEY" | tail -n1
-          
-          # 3) Verify BEGIN/END markers
-          if echo "$GPG_KEY" | grep -q "BEGIN PGP PRIVATE KEY BLOCK"; then
-            echo "✅ Header OK"
-          else
-            echo "❌ Missing BEGIN marker" >&2
-          fi
-          if echo "$GPG_KEY" | grep -q "END PGP PRIVATE KEY BLOCK"; then
-            echo "✅ Footer OK"
-          else
-            echo "❌ Missing END marker" >&2
-          fi
-          
-          # 4) Try importing and list what you have
-          echo "----importing----"
-          echo "$GPG_KEY" | gpg --batch --import   #  [oai_citation:1‡unix.stackexchange.com](https://unix.stackexchange.com/questions/184947/how-to-import-secret-gpg-key-copied-from-one-machine-to-another?utm_source=chatgpt.com)
-          echo "----secret keys in keyring----"
-          gpg --list-secret-keys --keyid-format LONG  
-
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
@@ -82,8 +44,8 @@ jobs:
           ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace \
             -PossrhUsername="${{ secrets.OSSRH_USERNAME }}" \
             -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}" \
-            -Dsigning.key="${{ secrets.MAVEN_KEY }}" \
-            -Dsigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
+            -Psigning.key="${{ secrets.MAVEN_KEY }}" \
+            -Psigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
 
   distribute:
     name: Distribute APK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
+      - name: Debug
+        run: |
+          echo "${{ secrets.OSSRH_USERNAME }}" | base64
+          echo "${{ secrets.OSSRH_PASSWORD }}" | base64
+
       - name: Publish artifacts
         run: |
           ./gradlew publishReleasePublicationToMavenCentralRepository --no-daemon --stacktrace \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+# Workflow name shown in GitHub Actions UI
+name: Publish Libraries to GitHub Packages
+
+# When to run this workflow:
+on:
+  # Only trigger on SemVer tags prefixed with 'v', e.g. 'v1.2.3'
+  push:
+    tags:
+      - 'v*.*.*'
+  # Allow manual (button) dispatch from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # First job: run your unit tests on every trigger
+  unit_tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      # Check out your repo
+      - uses: actions/checkout@v4
+
+      # Set up JDK 17 (Temurin distribution)
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Execute your Android unit tests
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --no-daemon --stacktrace
+
+  # Second job: publish artifacts, depends on successful unit_tests
+  publish:
+    name: Publish to GitHub Packages
+    needs: unit_tests
+    runs-on: ubuntu-latest
+    steps:
+      # Re-checkout code (always required at start of a job)
+      - uses: actions/checkout@v4
+
+      # Setup Java again, import GPG key for signing
+      - name: Setup Java, OSSRH creds & import GPG key
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Setup Android SDK so Gradle can build Android modules
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      # Publish your release publication to GitHub Packages
+      - name: Publish artifacts
+        run: |
+          ./gradlew \
+            publishReleasePublicationToGitHubPackagesRepository \
+            --no-daemon --stacktrace \
+            -Psigning.key="${{ secrets.MAVEN_KEY }}" \
+            -Psigning.password="${{ secrets.MAVEN_KEY_PASSWORD }}"
+        env:
+          # These environment variables are used by your settings.gradle.kts
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-06-17T15:25:38.645839Z">
+          <Target type="COLD_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/vid/.android/avd/Pixel_9_Pro_XL_API_35.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/README.md
+++ b/README.md
@@ -44,16 +44,72 @@ Declare desired dependencies in your project's `build.gradle.kts`:
 
 - You can use only `bunny-stream-api`:
    ```
-   implementation("net.bunnystream.bunny-stream-api:1.0.0")
+   implementation("net.bunnystream:api:1.0.0")
    ```
 - If you also need `bunny-stream-player`:
    ```
-   implementation("net.bunnystream.bunny-stream-player:1.0.0")
+   implementation("net.bunnystream:player:1.0.0")
    ```
 - If you need camera recording and live stream upload:
    ```
-   implementation("net.bunnystream.bunny-stream-camera-upload:1.0.0")
+   implementation("net.bunnystream:recording:1.0.0")
    ```
+
+1. Go to [Your Profile] => [Developer settings] => [Personal access token] => [Generate new token] on github.com
+2. Check read:packages
+3. Click Generate token
+4. Copy the generated token
+5. Add below lines to your ~/.gradle/gradle.properties (the path may be different on Windows) or export as environment variables:
+  ```
+  GITHUB_ACTOR={your github id}
+  GITHUB_TOKEN={the generated token}
+  ```
+6. Merge below lines to your <project root>/settings.gradle (If you are using the recent version of Android Gradle Plugin)
+  ```
+  dependencyResolutionManagement {
+    repositories {
+        maven {
+            url = uri("https://maven.pkg.github.com/BunnyWay/bunny-stream-android")
+            credentials {
+                // Use environment variables for GitHub Packages authentication
+                // Ensure GITHUB_ACTOR and GITHUB_TOKEN are set in your environment
+                // or gradle.properties file
+                username = providers.gradleProperty("gpr.user").orNull
+                    ?: providers.environmentVariable("GITHUB_ACTOR").orNull
+                    ?: System.getenv("GITHUB_ACTOR")
+                    ?: ""
+                password = providers.gradleProperty("gpr.key").orNull
+                    ?: providers.environmentVariable("GITHUB_TOKEN").orNull
+                    ?: System.getenv("GITHUB_TOKEN")
+                    ?: ""
+            }
+        }
+    }
+  }
+  ```
+or to your <project root>/build.gradle
+  ```
+  allprojects {
+      repositories {
+        maven {
+            url = uri("https://maven.pkg.github.com/BunnyWay/bunny-stream-android")
+            credentials {
+                // Use environment variables for GitHub Packages authentication
+                // Ensure GITHUB_ACTOR and GITHUB_TOKEN are set in your environment 
+                // or gradle.properties file
+                username = providers.gradleProperty("gpr.user").orNull
+                    ?: providers.environmentVariable("GITHUB_ACTOR").orNull
+                    ?: System.getenv("GITHUB_ACTOR")
+                    ?: ""
+                password = providers.gradleProperty("gpr.key").orNull
+                    ?: providers.environmentVariable("GITHUB_TOKEN").orNull
+                    ?: System.getenv("GITHUB_TOKEN")
+                    ?: ""
+            }
+        }
+    }
+  }
+  ```
 
 ## Initialization
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,15 +24,6 @@ android {
         }
     }
 
-    signingConfigs {
-        create("develop") {
-            storeFile = file("keystore/develop.keystore")
-            storePassword = "android"
-            keyAlias = "android"
-            keyPassword = "android"
-        }
-    }
-
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -43,11 +34,11 @@ android {
         }
 
         getByName("debug") {
-            signingConfig = signingConfigs.getByName("develop")
+
         }
 
         create("staging") {
-            signingConfig = signingConfigs.getByName("develop")
+
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,9 +73,9 @@ android {
 dependencies {
     // Project Modules
     // Gradle Project Dependencies: https://docs.gradle.org/current/userguide/java_plugin.html#sec:project_dependencies
-    implementation(project(":bunny-stream-api"))
-    implementation(project(":bunny-stream-player"))
-    implementation(project(":bunny-stream-camera-upload"))
+    implementation(project(":api"))
+    implementation(project(":player"))
+    implementation(project(":recording"))
 
     // AndroidX Core and Lifecycle
     // Core: https://developer.android.com/jetpack/androidx/releases/core

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.dokkaGfmMultiModule {
 
 // Default coordinates and plugin application for Android libraries
 allprojects {
-    group = "com.example.bunnystream"
+    group = "net.bunnystream"
     version = "1.0.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,11 @@ subprojects {
         pluginManager.withPlugin("maven-publish") {
             afterEvaluate {
                 extensions.configure<PublishingExtension> {
+                    val ossrhUser = project.findProperty("ossrhUsername") as String?
+                    val ossrhPass = project.findProperty("ossrhPassword") as String?
+                    logger.lifecycle("🔑 OSSRH username present: ${!ossrhUser.isNullOrBlank()}, length=${ossrhUser?.length}")
+                    logger.lifecycle("🔑 OSSRH password present: ${!ossrhPass.isNullOrBlank()}, length=${ossrhPass?.length}")
+
                     publications {
                         create<MavenPublication>("release") {
                             from(components["release"])
@@ -62,11 +67,8 @@ subprojects {
                     }
                     configure<SigningExtension> {
                         val rawKey = project.findProperty("signing.key") as String?
-                        logger.lifecycle("👀 signing.key present=${rawKey != null}, length=${rawKey?.length ?: 0}")
-                        rawKey?.lines()?.take(2)?.forEachIndexed { i, line ->
-                            logger.lifecycle("  line ${i+1}: ${line.take(30)}…")
-                        }
-                        useInMemoryPgpKeys(rawKey.orEmpty(), project.findProperty("signing.password") as String?)
+                        val password = project.findProperty("signing.password") as String?
+                        useInMemoryPgpKeys(rawKey.orEmpty(), password.orEmpty())
                         sign(publications["release"])
                     }
                     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,12 +35,6 @@ tasks.dokkaGfmMultiModule {
     outputDirectory.set(file("docs"))
 }
 
-// Default coordinates and plugin application for Android libraries
-allprojects {
-    group = "net.bunnystream"
-    version = "1.0.0"
-}
-
 subprojects {
     // Only configure publishing in Android-library modules
     pluginManager.withPlugin("com.android.library") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,3 @@
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.kotlin.dsl.configure
-import org.gradle.plugins.signing.SigningExtension
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     // Android plugins
@@ -52,17 +47,12 @@ subprojects {
         pluginManager.withPlugin("maven-publish") {
             afterEvaluate {
                 extensions.configure<PublishingExtension> {
-                    val ossrhUser = project.findProperty("ossrhUsername") as String?
-                    val ossrhPass = project.findProperty("ossrhPassword") as String?
-                    logger.lifecycle("🔑 OSSRH username present: ${!ossrhUser.isNullOrBlank()}, length=${ossrhUser?.length}")
-                    logger.lifecycle("🔑 OSSRH password present: ${!ossrhPass.isNullOrBlank()}, length=${ossrhPass?.length}")
-
                     publications {
                         create<MavenPublication>("release") {
                             from(components["release"])
-                            groupId    = project.group.toString()
+                            groupId = project.group.toString()
                             artifactId = project.name
-                            version    = project.version.toString()
+                            version = project.version.toString()
                         }
                     }
                     configure<SigningExtension> {
@@ -73,11 +63,13 @@ subprojects {
                     }
                     repositories {
                         maven {
-                            name = "MavenCentral"
-                            url  = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                            name = "GitHubPackages"
+                            url = uri("https://maven.pkg.github.com/BunnyWay/bunny-stream-android")
                             credentials {
-                                username = findProperty("ossrhUsername") as String? ?: ""
-                                password = findProperty("ossrhPassword") as String? ?: ""
+                                username = project.findProperty("gpr.user") as String?
+                                    ?: System.getenv("GITHUB_ACTOR")
+                                password = project.findProperty("gpr.key") as String?
+                                    ?: System.getenv("GITHUB_TOKEN")
                             }
                         }
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.plugins.signing.SigningExtension
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     // Android plugins
@@ -23,9 +27,58 @@ plugins {
     // Documentation
     // https://kotlin.github.io/dokka
     id("org.jetbrains.dokka") version "2.0.0"
+
+    //id("signing")                      apply false
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0" apply false
+
+    `maven-publish`
+    signing
 }
 
 tasks.dokkaGfmMultiModule {
     moduleName.set("Bunny Stream Android API")
     outputDirectory.set(file("docs"))
+}
+
+// Default coordinates and plugin application for Android libraries
+allprojects {
+    group = "com.example.bunnystream"
+    version = "1.0.0"
+}
+
+subprojects {
+    // Only configure publishing in Android-library modules
+    pluginManager.withPlugin("com.android.library") {
+        pluginManager.withPlugin("maven-publish") {
+            afterEvaluate {
+                extensions.configure<PublishingExtension> {
+                    publications {
+                        create<MavenPublication>("release") {
+                            from(components["release"])
+                            groupId    = project.group.toString()
+                            artifactId = project.name
+                            version    = project.version.toString()
+                        }
+                    }
+                    configure<SigningExtension> {
+                        useInMemoryPgpKeys(
+                            project.findProperty("signing.key")     as String?,
+                            project.findProperty("signing.password") as String?
+                        )
+                        sign(publications["release"])
+                    }
+                    repositories {
+                        maven {
+                            name = "MavenCentral"
+                            url  = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                            credentials {
+                                username = findProperty("ossrhUsername") as String? ?: ""
+                                password = findProperty("ossrhPassword") as String? ?: ""
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,10 +61,12 @@ subprojects {
                         }
                     }
                     configure<SigningExtension> {
-                        useInMemoryPgpKeys(
-                            project.findProperty("signing.key")     as String?,
-                            project.findProperty("signing.password") as String?
-                        )
+                        val rawKey = project.findProperty("signing.key") as String?
+                        logger.lifecycle("👀 signing.key present=${rawKey != null}, length=${rawKey?.length ?: 0}")
+                        rawKey?.lines()?.take(2)?.forEachIndexed { i, line ->
+                            logger.lifecycle("  line ${i+1}: ${line.take(30)}…")
+                        }
+                        useInMemoryPgpKeys(rawKey.orEmpty(), project.findProperty("signing.password") as String?)
                         sign(publications["release"])
                     }
                     repositories {

--- a/bunny-stream-api/build.gradle.kts
+++ b/bunny-stream-api/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20"
+    id("maven-publish")
+    id("signing")
 }
 
 android {
@@ -60,6 +62,13 @@ android {
 
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14" // Replace with the correct version
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -206,4 +215,11 @@ tasks.register("fixGeneratedFiles") {
             logger.lifecycle("fixGeneratedFiles: file not found: ${fileToFix.absolutePath}")
         }
     }
+}
+
+afterEvaluate {
+    tasks.matching { it.name.endsWith("sourceReleaseJar") }
+        .configureEach {
+            dependsOn("openApiGenerateAll")
+        }
 }

--- a/bunny-stream-camera-upload/build.gradle.kts
+++ b/bunny-stream-camera-upload/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20"
+    id("maven-publish")
+    id("signing")
 }
 
 android {
@@ -45,6 +47,13 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14" // Replace with the correct version
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 

--- a/bunny-stream-camera-upload/build.gradle.kts
+++ b/bunny-stream-camera-upload/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.dokkaGfm {
 
 dependencies {
     // Project module dependency
-    implementation(project(":bunny-stream-api"))
+    implementation(project(":api"))
 
     // AndroidX and Material
     // https://developer.android.com/jetpack/androidx/releases/core

--- a/bunny-stream-player/build.gradle.kts
+++ b/bunny-stream-player/build.gradle.kts
@@ -71,7 +71,7 @@ tasks.dokkaGfm {
 dependencies {
     // Project Module
     // https://docs.gradle.org/current/userguide/java_plugin.html#sec:project_dependencies
-    implementation(project(":bunny-stream-api"))
+    implementation(project(":api"))
 
     // AndroidX and Material
     // https://developer.android.com/jetpack/androidx/releases/core

--- a/bunny-stream-player/build.gradle.kts
+++ b/bunny-stream-player/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("kotlin-parcelize")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.20"
+    id("maven-publish")
+    id("signing")
 }
 
 android {
@@ -45,6 +47,13 @@ android {
         kotlinCompilerExtensionVersion = "1.5.14" // Replace with the correct version
     }
     viewBinding.enable = true
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 tasks.dokkaGfm {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-ossrhUsername=${OSSRH_USERNAME}
-ossrhPassword=${OSSRH_PASSWORD}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,3 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 ossrhUsername=${OSSRH_USERNAME}
 ossrhPassword=${OSSRH_PASSWORD}
-signing.key=${MAVEN_KEY}
-signing.password=${MAVEN_KEY_PASSWORD}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+ossrhUsername=${OSSRH_USERNAME}
+ossrhPassword=${OSSRH_PASSWORD}
+signing.key=${MAVEN_KEY}
+signing.password=${MAVEN_KEY_PASSWORD}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,3 +19,7 @@ include(":app")
 include(":bunny-stream-api")
 include(":bunny-stream-player")
 include(":bunny-stream-camera-upload")
+
+project(":bunny-stream-api").name = "api"
+project(":bunny-stream-player").name = "player"
+project(":bunny-stream-camera-upload").name = "recording"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,19 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
+        maven {
+            url = uri("https://maven.pkg.github.com/BunnyWay/bunny-stream-android")
+            credentials {
+                // Use environment variables for GitHub Packages authentication
+                // Ensure GITHUB_ACTOR and GITHUB_TOKEN are set in your environment
+                username = providers.environmentVariable("GITHUB_ACTOR").orNull
+                    ?: System.getenv("GITHUB_ACTOR")
+                            ?: ""
+                password = providers.environmentVariable("GITHUB_TOKEN").orNull
+                    ?: System.getenv("GITHUB_TOKEN")
+                            ?: ""
+            }
+        }
     }
 }
 


### PR DESCRIPTION
	•	CI workflows reorganized
	•	main.yml renamed to “Test and Upload Artifact App”, now triggers on pushes to main (and manual dispatch), drops lint/instrumentation jobs, and runs two steps: unit tests and a “distribute” job that builds app-debug.apk and uploads it as a GitHub Actions artifact.
	•	publish.yml extracted into its own file, triggers on v*.*.* tags (SemVer), runs the same unit tests, then publishes library modules to GitHub Packages with signing and uses GITHUB_ACTOR/GITHUB_TOKEN for repo credentials.
	•	Documentation streamlined
	•	README now reflects new artifact coordinates (net.bunnystream:api|player|recording:1.0.0)
	•	Includes a brief PAT setup guide and the settings.gradle.kts snippet for adding GitHub Packages with gpr.user/gpr.key (or env vars).
	•	Gradle build refactored
	•	Removed the old allprojects { group, version } block.
	•	Root build.gradle.kts adds the maven-publish and signing plugins, and a subprojects block that auto-publishes Android library modules to GitHub Packages with in-memory PGP signing and credentials lookup.
	•	Each library module applies maven-publish + signing and configures singleVariant("release") for sources/Javadoc JARs.
	•	App module no longer has custom signing configs; its dependencies updated to use the renamed module names (:api, :player, :recording).
	•	Settings and module naming
	•	settings.gradle.kts now centralizes all repositories (including GitHub Packages with credential lookup) under dependencyResolutionManagement.
	•	Projects renamed so that bunny-stream-api → api, bunny-stream-player → player, and bunny-stream-camera-upload → recording.