### PR TITLE
Add auto-contrast for the position/duration

### DIFF
--- a/app/src/main/java/net/bunny/android/demo/player/PlayerScreen.kt
+++ b/app/src/main/java/net/bunny/android/demo/player/PlayerScreen.kt
@@ -410,6 +410,12 @@ fun BunnyPlayerComposable(
 
                 player.setPlaybackSpeedConfig(speedConfig)
 
+                // Opt the demo app in to auto-contrast for the position/duration readout so the
+                // text stays legible regardless of scene brightness. Off by default in the SDK.
+                player.autoProgressTextColor = true
+
+//                player.progressTextColor = android.graphics.Color.RED
+
                 // Enable resume position only if enabled in settings
                 if (resumeEnabled) {
                     player.enableResumePosition(

--- a/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyStreamPlayer.kt
+++ b/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyStreamPlayer.kt
@@ -64,6 +64,32 @@ class BunnyStreamPlayer @JvmOverloads constructor(
             playerView.iconSet = value
         }
 
+    /**
+     * When `true`, the player periodically samples the video frame behind the position/duration
+     * readout and flips the text between black and white based on luminance, so the readout stays
+     * legible regardless of scene brightness. Defaults to `false` to preserve existing behavior;
+     * opt in from your app.
+     *
+     * Forwards to [BunnyPlayerView.autoProgressTextColor].
+     */
+    var autoProgressTextColor: Boolean
+        get() = playerView.autoProgressTextColor
+        set(value) {
+            playerView.autoProgressTextColor = value
+        }
+
+    /**
+     * Manual override for the position/duration text color. Has no lasting effect while
+     * [autoProgressTextColor] is enabled — the sampler overrides it on each tick.
+     *
+     * Forwards to [BunnyPlayerView.progressTextColor].
+     */
+    var progressTextColor: Int
+        get() = playerView.progressTextColor
+        set(value) {
+            playerView.progressTextColor = value
+        }
+
     private val bunnyPlayer = DefaultBunnyPlayer.getInstance(context)
     private var progressListener: BunnyPlayer.ProgressListener? = null
     private var progressListenerJob: Job? = null

--- a/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/widget/BunnyPlayerView.kt
+++ b/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/widget/BunnyPlayerView.kt
@@ -1,20 +1,27 @@
 package net.bunny.bunnystreamplayer.ui.widget
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.Looper
 import android.util.AttributeSet
 import android.util.Log
 import android.view.Gravity
 import android.view.Menu
+import android.view.PixelCopy
+import android.view.SurfaceView
+import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.ColorInt
 import androidx.annotation.Dimension
 import androidx.appcompat.widget.PopupMenu
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -61,6 +68,18 @@ class BunnyPlayerView @JvmOverloads constructor(
 
     companion object {
         private const val TAG = "BunnyPlayerView"
+
+        /** How often [autoProgressTextColor] re-samples the video while the controller is visible. */
+        private const val PROGRESS_COLOR_SAMPLE_INTERVAL_MS = 1_500L
+
+        /** Average sRGB luminance threshold above which we switch to black text. */
+        private const val LUMINANCE_THRESHOLD = 0.55
+
+        /** Fraction of the video surface height sampled from the bottom (where the readout sits). */
+        private const val SAMPLE_HEIGHT_FRACTION = 0.15f
+
+        /** Cap sample bitmap dimensions so we don't burn CPU on 4K surfaces. */
+        private const val MAX_SAMPLE_DIMENSION = 64
     }
 
     interface FullscreenListener {
@@ -148,6 +167,37 @@ class BunnyPlayerView @JvmOverloads constructor(
             applyStyle()
         }
 
+    /**
+     * Text color used for the position counter, total duration, and the `/` divider between
+     * them in the bottom controls. Defaults to [Color.WHITE] so the readout stays legible against
+     * the dark letterbox. The Bunny dashboard does not expose this setting — set it on the view
+     * from your app code to override.
+     *
+     * When [autoProgressTextColor] is enabled, this value is overridden roughly every
+     * [PROGRESS_COLOR_SAMPLE_INTERVAL_MS] ms based on the video pixels behind the readout.
+     */
+    @ColorInt
+    var progressTextColor: Int = Color.WHITE
+        set(value) {
+            field = value
+            applyStyle()
+        }
+
+    /**
+     * When `true`, the SDK periodically samples the video frame behind the progress/duration
+     * text and switches [progressTextColor] between black and white based on average luminance,
+     * so the readout stays legible regardless of scene brightness. Sampling only runs while the
+     * controller is visible and is suspended when the view detaches from the window.
+     */
+    var autoProgressTextColor: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            if (value) progressColorSampler.start() else progressColorSampler.stop()
+        }
+
+    private val progressColorSampler = ProgressTextColorSampler()
+
     private var playerSettings: PlayerSettings? = null
         set(value) {
             Log.d(TAG, "set playerSettings: $value")
@@ -194,7 +244,7 @@ class BunnyPlayerView @JvmOverloads constructor(
     }
 
     private val progressDurationDivider by lazy {
-        findViewById<View>(R.id.position_duration_divider)
+        findViewById<TextView>(R.id.position_duration_divider)
     }
 
     private val timeBar by lazy {
@@ -600,6 +650,10 @@ class BunnyPlayerView @JvmOverloads constructor(
         settingsButton.setImageResource(iconSet.settingsIcon)
         muteButton.setStateIcons(iconSet.volumeOnIcon, iconSet.volumeOffIcon)
 
+        progressTextView.setTextColor(progressTextColor)
+        durationTextView.setTextColor(progressTextColor)
+        progressDurationDivider.setTextColor(progressTextColor)
+
         val fullScreenIcon = if (isFullscreen) {
             iconSet.fullscreenOffIcon
         } else {
@@ -760,5 +814,150 @@ class BunnyPlayerView @JvmOverloads constructor(
     fun showError(message: String) {
         errorWrapper.isVisible = true
         errorMessage.text = message
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (autoProgressTextColor) progressColorSampler.start()
+    }
+
+    override fun onDetachedFromWindow() {
+        progressColorSampler.stop()
+        super.onDetachedFromWindow()
+    }
+
+    /**
+     * Releases background resources held by the auto-contrast sampler. Call from your
+     * Activity/Fragment teardown if you toggled [autoProgressTextColor] — otherwise the sampler's
+     * worker thread persists until the view is garbage collected.
+     */
+    fun releaseAutoProgressTextColorResources() {
+        progressColorSampler.release()
+    }
+
+    /**
+     * Samples a small bottom strip of the video surface on a background thread, computes the
+     * average WCAG relative luminance, and posts back to the main thread to flip
+     * [progressTextColor] between black and white. Only ticks while the controller is visible.
+     */
+    private inner class ProgressTextColorSampler {
+
+        private val workerThread = HandlerThread("bunny-progress-color-sampler").apply { start() }
+        private val workerHandler = Handler(workerThread.looper)
+        private val mainHandler = Handler(Looper.getMainLooper())
+
+        private var running = false
+        private var released = false
+
+        private val tick = Runnable {
+            if (!running) return@Runnable
+            sample()
+            scheduleNext()
+        }
+
+        fun start() {
+            if (released || running) return
+            running = true
+            mainHandler.post(tick)
+        }
+
+        fun stop() {
+            running = false
+            mainHandler.removeCallbacks(tick)
+        }
+
+        /**
+         * Permanently shuts down the worker thread. After this, calling [start] is a no-op until
+         * the enclosing view is recreated.
+         */
+        fun release() {
+            if (released) return
+            released = true
+            stop()
+            workerThread.quitSafely()
+        }
+
+        private fun scheduleNext() {
+            if (!running) return
+            mainHandler.postDelayed(tick, PROGRESS_COLOR_SAMPLE_INTERVAL_MS)
+        }
+
+        private fun sample() {
+            if (!isControllerFullyVisible) return
+            val surface = videoSurfaceView ?: return
+            val w = surface.width
+            val h = surface.height
+            if (w <= 0 || h <= 0) return
+
+            val sampleH = (h * SAMPLE_HEIGHT_FRACTION).toInt().coerceAtLeast(8)
+            // PixelCopy doesn't scale, so the destination must match the source rect size.
+            // We compensate by reading with a stride in [applyLuminance].
+            val srcRect = Rect(0, h - sampleH, w, h)
+            val bitmap = Bitmap.createBitmap(w, sampleH, Bitmap.Config.ARGB_8888)
+
+            when (surface) {
+                is SurfaceView -> {
+                    try {
+                        PixelCopy.request(surface, srcRect, bitmap, { result ->
+                            if (result == PixelCopy.SUCCESS) applyLuminance(bitmap)
+                            bitmap.recycle()
+                        }, workerHandler)
+                    } catch (e: IllegalArgumentException) {
+                        // Surface not yet ready (no underlying buffer); try again next tick.
+                        Log.v(TAG, "PixelCopy not ready: ${e.message}")
+                        bitmap.recycle()
+                    }
+                }
+                is TextureView -> {
+                    val full = surface.getBitmap(w, h)
+                    if (full != null) {
+                        val cropped = Bitmap.createBitmap(full, 0, h - sampleH, w, sampleH)
+                        full.recycle()
+                        applyLuminance(cropped)
+                        cropped.recycle()
+                    }
+                    bitmap.recycle()
+                }
+                else -> bitmap.recycle()
+            }
+        }
+
+        /**
+         * Computes the average sRGB relative luminance of the sampled bitmap by reading every
+         * `stride`th pixel — that keeps the work to ~MAX_SAMPLE_DIMENSION^2 reads regardless of
+         * surface resolution, instead of allocating a full IntArray of the source on every tick.
+         */
+        private fun applyLuminance(bitmap: Bitmap) {
+            val width = bitmap.width
+            val height = bitmap.height
+            val stride = maxOf(1, minOf(width, height) / MAX_SAMPLE_DIMENSION)
+
+            var lumSum = 0.0
+            var count = 0
+            var y = 0
+            while (y < height) {
+                var x = 0
+                while (x < width) {
+                    val px = bitmap.getPixel(x, y)
+                    val r = Color.red(px) / 255.0
+                    val g = Color.green(px) / 255.0
+                    val b = Color.blue(px) / 255.0
+                    // sRGB relative luminance (per WCAG 2.x).
+                    lumSum += 0.2126 * r + 0.7152 * g + 0.0722 * b
+                    count++
+                    x += stride
+                }
+                y += stride
+            }
+            if (count == 0) return
+            val avgLum = lumSum / count
+            val pick = if (avgLum > LUMINANCE_THRESHOLD) Color.BLACK else Color.WHITE
+
+            mainHandler.post {
+                if (running && progressTextColor != pick) {
+                    progressTextColor = pick
+                }
+            }
+        }
     }
 }

--- a/bunny-stream-player/src/main/res/layout/view_media_controller.xml
+++ b/bunny-stream-player/src/main/res/layout/view_media_controller.xml
@@ -124,6 +124,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:text="00:00"
+                android:textColor="@android:color/white"
                 android:paddingVertical="8dp"/>
 
             <TextView
@@ -131,6 +132,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="/"
+                android:textColor="@android:color/white"
                 android:paddingVertical="8dp"
                 android:paddingHorizontal="3dp"/>
 
@@ -139,6 +141,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:text="00:10"
+                android:textColor="@android:color/white"
                 android:paddingVertical="8dp"
                 android:paddingRight="8dp"/>
 


### PR DESCRIPTION
### Describe the bug

When using the `BunnyStreamPlayer` Android SDK, the position counter, `/` divider, and total duration in the bottom controls are rendered in a fixed white color. Against bright video content — snow, white skies, light backgrounds, brand assets on a white field — the readout becomes effectively illegible because there is no contrast between the text and the frame behind it.

The text color is not exposed in the Bunny.net dashboard and, on `main`, there is no public API on `BunnyStreamPlayer` to override it from app code either. Developers integrating the SDK are blocked from fixing the contrast problem themselves without forking the SDK and modifying `view_media_controller.xml` and `BunnyPlayerView` directly.

### Steps to reproduce

1. Integrate `BunnyStreamPlayer` into an Android app using the SDK as published.
2. Play any video that contains long stretches of bright content in the lower portion of the frame (e.g., outdoor / snow / white-product footage).
3. Tap the player to reveal the controls.
4. Observe that the position counter and total duration in the bottom-left disappear into the bright background — white text on a near-white frame.

### Expected behavior

The SDK should either keep the readout legible automatically as the underlying video brightness changes, or expose a way to set the text color from app code so the integrating app can solve the contrast problem itself.

### Proposed Fix

Expose two new properties on `BunnyStreamPlayer` (forwarded to `BunnyPlayerView`):

- `progressTextColor: Int` — manual override for the position / divider / duration text color. Defaults to `Color.WHITE` to preserve existing behavior.
- `autoProgressTextColor: Boolean` — when enabled, the SDK periodically samples the video pixels behind the readout on a background thread, computes the average sRGB relative luminance (WCAG 2.x), and flips `progressTextColor` between black and white so the readout stays legible regardless of scene brightness. Defaults to `false` so existing integrations are unaffected; opt in from your app.

Implementation notes:

- Sampling runs on a dedicated `HandlerThread`, only ticks while the controller is visible, and is suspended in `onDetachedFromWindow`. A `releaseAutoProgressTextColorResources()` hook is provided for explicit teardown.
- Reads use `PixelCopy` for `SurfaceView` and `TextureView.getBitmap` for `TextureView`, with a strided scan capped at ~64×64 effective reads so the cost is bounded on 4K surfaces.
- Demo app (`PlayerScreen.kt`) opts in to `autoProgressTextColor = true` so reviewers can verify the behavior end-to-end.