### PR TITLE
Expose public seekTo() method in BunnyPlayer and BunnyStreamPlayer

### DIFF
--- a/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyPlayer.kt
+++ b/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyPlayer.kt
@@ -31,6 +31,13 @@ interface BunnyPlayer {
     fun play()
 
     /**
+     * Seek to a specific playback position in milliseconds.
+     *
+     * @param position Position in milliseconds.
+     */
+    fun seekTo(position: Long)
+
+    /**
      * Get current position of video in milliseconds
      */
     fun getCurrentPosition(): Long

--- a/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyStreamPlayer.kt
+++ b/bunny-stream-player/src/main/java/net/bunny/bunnystreamplayer/ui/BunnyStreamPlayer.kt
@@ -388,6 +388,11 @@ class BunnyStreamPlayer @JvmOverloads constructor(
         bunnyPlayer.play()
         // Auto-save will start automatically via lifecycle observer
     }
+
+    override fun seekTo(position: Long) {
+        bunnyPlayer.seekTo(position)
+    }
+
     override fun getCurrentPosition(): Long {
         return bunnyPlayer.getCurrentPosition()
     }


### PR DESCRIPTION
## Summary

This PR exposes programmatic seeking through the public player API.

### Changes

* Added `seekTo(position: Long)` to `BunnyPlayer`
* Implemented `seekTo(position: Long)` in `BunnyStreamPlayer`
* Delegates directly to the existing internal `bunnyPlayer.seekTo()` implementation

### Use Cases

* Synchronized playback / watch-party applications
* Resume playback from external state
* Chapter navigation
* Custom playback controls
* Multi-device playback synchronization

### Notes

The underlying player already supports seeking internally. This change simply exposes that functionality through the public API.

The project builds successfully after these changes.
