### PR TITLE
Add OSS community and release tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a reproducible problem in Bunny Stream Android.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please do not include Bunny access keys, signed URLs, or other secrets.
+  - type: input
+    id: sdk-version
+    attributes:
+      label: SDK version
+      description: Which version are you using?
+      placeholder: "3.3.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      multiple: true
+      options:
+        - api
+        - player
+        - recording
+        - tv
+        - demo app
+        - documentation
+        - build/publishing
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      placeholder: "Android 14 / API 34"
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device or emulator
+      placeholder: "Pixel 8, Samsung TV, Android TV emulator, etc."
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable reproduction you can.
+      placeholder: |
+        1. Initialize BunnyStreamApi with ...
+        2. Call ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, stack traces, screenshots, or sample code
+      description: Redact secrets before posting.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues.
+          required: true
+        - label: I removed access keys, tokens, signed URLs, and private data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bunny Stream documentation
+    url: https://docs.bunny.net/stream/mobile-sdk
+    about: Read the official Bunny Stream Mobile SDK documentation.
+  - name: Bunny support
+    url: https://support.bunny.net/
+    about: Contact Bunny support for account, billing, dashboard, or production support questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest an improvement for Bunny Stream Android.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to build, and what is currently hard or missing?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the API, behavior, or documentation you would like to see.
+    validations:
+      required: true
+  - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      multiple: true
+      options:
+        - api
+        - player
+        - recording
+        - tv
+        - demo app
+        - documentation
+        - build/publishing
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Are there workarounds or other designs you considered?
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, screenshots, related issues, or SDK examples.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues.
+          required: true
+        - label: This request is about the Android SDK, not general Bunny Stream product support.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Refactor or cleanup
+- [ ] CI/build/release
+- [ ] Breaking change
+
+## Affected Areas
+
+- [ ] API module
+- [ ] Player module
+- [ ] Camera recording/upload module
+- [ ] Android TV module
+- [ ] Demo app
+- [ ] Documentation
+- [ ] Build or publishing
+
+## Testing
+
+<!-- Describe what you ran. Include device/emulator details for UI, playback, recording, or TV changes. -->
+
+- [ ] `./gradlew testDebugUnitTest --no-daemon --stacktrace`
+- [ ] `./gradlew :app:assembleDebug --no-daemon`
+- [ ] Manual playback/upload/recording test
+- [ ] Not run, reason:
+
+## SDK User Impact
+
+<!-- Mention public API changes, migration steps, dependency changes, or behavior changes. -->
+
+## AI Assistance
+
+- [ ] No substantial AI assistance was used.
+- [ ] AI helped with this PR; I reviewed and understand the final changes.
+
+## Checklist
+
+- [ ] The PR is focused on one clear change.
+- [ ] Public API or behavior changes are documented.
+- [ ] Tests or manual verification are included where appropriate.
+- [ ] No secrets, access keys, or private data are included.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,81 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "gradle"
+    groups:
+      android-build-tooling:
+        patterns:
+          - "com.android.*"
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.dokka*"
+          - "io.gitlab.arturbosch.detekt*"
+          - "org.openapi.generator*"
+          - "com.vanniktech.maven.publish*"
+        update-types:
+          - "minor"
+          - "patch"
+      media3-minor-patch:
+        patterns:
+          - "androidx.media3:*"
+        update-types:
+          - "minor"
+          - "patch"
+      androidx-minor-patch:
+        patterns:
+          - "androidx.*"
+        update-types:
+          - "minor"
+          - "patch"
+      networking-minor-patch:
+        patterns:
+          - "com.squareup.okhttp3:*"
+          - "com.squareup.moshi:*"
+          - "io.ktor:*"
+          - "com.google.code.gson:*"
+          - "io.tus.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      ui-and-utility-minor-patch:
+        patterns:
+          - "com.google.android.material:*"
+          - "com.github.bumptech.glide:*"
+          - "io.arrow-kt:*"
+          - "com.charleskorn.kaml:*"
+          - "com.github.pedroSG94.RootEncoder:*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,54 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: Player
+      labels:
+        - player
+        - media3
+        - exoplayer
+    - title: Uploads and Recording
+      labels:
+        - upload
+        - video-upload
+        - camera-upload
+        - recording
+        - tus
+    - title: Android TV
+      labels:
+        - android-tv
+        - tv
+    - title: API
+      labels:
+        - api
+        - openapi
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Build, CI, and Dependencies
+      labels:
+        - dependencies
+        - gradle
+        - github-actions
+        - ci
+        - build
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to Bunny Stream Android are documented in this file.
+
+This project follows semantic versioning where possible:
+
+- `MAJOR` versions may include breaking API or behavior changes.
+- `MINOR` versions add functionality in a backward-compatible way.
+- `PATCH` versions include backward-compatible bug fixes and maintenance updates.
+
+## [Unreleased]
+
+### Added
+
+- Nothing yet.
+
+### Changed
+
+- Nothing yet.
+
+### Fixed
+
+- Nothing yet.
+
+### Deprecated
+
+- Nothing yet.
+
+### Removed
+
+- Nothing yet.
+
+### Security
+
+- Nothing yet.
+
+## Release Notes Guidance
+
+When preparing a release, move relevant items from `[Unreleased]` into a new version section:
+
+```markdown
+## [3.4.0] - 2026-06-05
+
+### Added
+
+- Add ...
+
+### Fixed
+
+- Fix ...
+```
+
+For SDK users, call out:
+
+- public API changes,
+- migration steps,
+- dependency upgrades that may affect apps,
+- playback, upload, recording, or Android TV behavior changes,
+- security fixes.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want Bunny Stream Android to be a welcoming, useful, and professional open source project for everyone building video experiences on Android.
+
+Everyone participating in this project is expected to act with respect, patience, and good intent. That includes maintainers, contributors, issue reporters, and anyone joining discussions.
+
+## Expected Behavior
+
+- Be respectful and constructive, especially when giving feedback.
+- Assume good intent, but clarify when something is unclear.
+- Keep discussions focused on the project, its users, and its maintainability.
+- Welcome newcomers and help them find the right place to contribute.
+- Respect differences in experience level, background, language, and perspective.
+
+## Unacceptable Behavior
+
+- Harassment, threats, insults, or discriminatory language.
+- Personal attacks or repeated unconstructive criticism.
+- Publishing private information without consent.
+- Spam, trolling, or intentionally derailing technical discussions.
+- Abusive behavior toward maintainers, contributors, or users.
+
+## Enforcement
+
+Maintainers may moderate, edit, hide, or remove comments, issues, pull requests, or other contributions that do not meet this Code of Conduct. Serious or repeated violations may result in temporary or permanent restrictions from participating in the project.
+
+If you see behavior that violates this Code of Conduct, please contact the maintainers privately at support@bunny.net with the subject line `[Code of Conduct] bunny-stream-android`.
+
+Reports will be reviewed with care and handled as confidentially as practical.
+
+## Attribution
+
+This Code of Conduct is inspired by the Contributor Covenant and adapted for the Bunny Stream SDK repositories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Bunny Stream Android
+
+Thanks for helping improve Bunny Stream Android. This SDK is used by developers who need reliable video playback, uploads, camera recording, and Bunny Stream API access in Android apps, so small improvements to clarity, stability, and developer experience matter a lot.
+
+## Good First Contributions
+
+Good places to start:
+
+- README and documentation improvements
+- Small bug fixes with clear reproduction steps
+- Sample app fixes
+- Test coverage for API, uploader, player, recording, or TV behavior
+- Better error messages or edge-case handling
+- Improvements to CI reliability
+
+If you are unsure whether a change fits, open an issue first and describe the problem you want to solve.
+
+## Development Setup
+
+Requirements:
+
+- Android Studio
+- JDK 17
+- Android SDK matching the project configuration
+- Gradle wrapper from this repository
+
+Useful commands:
+
+```bash
+./gradlew testDebugUnitTest --no-daemon --stacktrace
+./gradlew :app:assembleDebug --no-daemon
+./gradlew detekt --no-daemon
+```
+
+For release and publishing behavior, see the existing GitHub Actions workflows and Gradle publishing configuration.
+
+## Project Areas
+
+- `api`: Bunny Stream REST API integration, authentication, generated OpenAPI client, upload helpers
+- `player`: Media3/ExoPlayer-based Bunny Stream player
+- `recording`: camera recording and upload UI/components
+- `tv`: Android TV optimized playback experience
+- `app`: demo app and integration examples
+
+Try to keep changes scoped to the package or module they affect.
+
+## Pull Request Guidelines
+
+Before opening a pull request:
+
+- Make sure the change solves one clear problem.
+- Add or update tests when behavior changes.
+- Update README or module docs when public APIs or setup steps change.
+- Keep generated files separate from handwritten logic when practical.
+- Avoid unrelated formatting-only changes in large files.
+- Verify the sample app still builds if your change touches UI, player, recording, or initialization.
+
+Pull requests should include:
+
+- What changed
+- Why the change is needed
+- How it was tested
+- Any migration notes for SDK users
+
+## API and Compatibility
+
+This repository publishes Android libraries used by external applications. Please be careful with:
+
+- Public API renames or removals
+- Behavior changes in upload, playback, authentication, or recording flows
+- Minimum SDK changes
+- Dependency version upgrades
+- Changes to Maven coordinates or publishing metadata
+
+If a change may be breaking, call it out clearly in the PR description.
+
+## Using AI Tools
+
+AI tools are welcome when they help you work faster or improve quality, but contributors remain responsible for the final contribution.
+
+When using AI:
+
+- Review and understand all generated code before submitting it.
+- Do not paste access keys, signing keys, customer data, private logs, or other secrets into AI tools.
+- Prefer small, reviewable changes over large generated rewrites.
+- Mention substantial AI assistance in the PR description when it materially shaped the implementation.
+- Make sure generated code follows the existing style and architecture.
+
+
+## Reporting Bugs
+
+Please use the bug report template and include:
+
+- SDK version
+- Android version and device/emulator
+- Module affected (`api`, `player`, `recording`, `tv`, or `app`)
+- Minimal reproduction steps
+- Expected and actual behavior
+- Logs, stack traces, or screenshots when useful
+
+Never include Bunny access keys or other secrets in issues.
+
+## Security Issues
+
+Please do not report security vulnerabilities in public issues. See `SECURITY.md` for the private reporting process.
+
+## License
+
+By contributing, you agree that your contribution will be licensed under the MIT License used by this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are prioritized for the latest released version of Bunny Stream Android. When practical, fixes may also be backported to recent minor versions that are still widely used.
+
+Please keep your application on the latest SDK release whenever possible.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+To report a vulnerability, contact us privately at support@bunny.net with the subject line:
+
+```text
+[Security] bunny-stream-android
+```
+
+Include as much detail as you can safely share:
+
+- Affected module (`api`, `player`, `recording`, `tv`, or sample app)
+- Affected version or commit
+- Steps to reproduce
+- Impact and possible attack scenario
+- Any proof of concept, logs, or screenshots
+- Suggested fix, if you have one
+
+Do not include production access keys, signing keys, customer data, or other secrets.
+
+## What to Expect
+
+We aim to acknowledge security reports within a reasonable time and will follow up if we need more information. If the report is valid, we will work on a fix, coordinate disclosure timing where appropriate, and publish release notes or advisories when the issue is resolved.
+
+## Scope
+
+In scope:
+
+- Authentication or authorization flaws in SDK API calls
+- Unsafe handling of access keys, tokens, or signed URLs
+- Upload or playback behavior that could expose private content
+- Dependency or build configuration issues that affect SDK users
+- Security-sensitive issues in camera recording or Android TV playback flows
+
+Out of scope:
+
+- Vulnerabilities requiring a compromised developer machine
+- Issues only present in unsupported SDK versions
+- Denial-of-service scenarios with no practical impact on SDK users
+- Reports without enough detail to reproduce or assess
+
+## AI and Security
+
+Maintainers may use AI-assisted tooling to triage reports or review patches, but vulnerability details should be handled carefully. Do not send secrets, private customer data, or unreleased vulnerability details to third-party AI systems unless explicitly approved by the maintainers responsible for the report.


### PR DESCRIPTION
## Summary

Adds OSS community and release tooling for the Bunny Stream Android SDK.

## What changed

- Add issue templates for bug reports and feature requests
- Add pull request template
- Add CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, and CHANGELOG files
- Add Dependabot configuration for GitHub Actions and Gradle dependencies
- Add GitHub generated release notes configuration

## Notes

This should improve GitHub Community Profile health, make contributions easier to triage, and provide a cleaner release process for SDK users.